### PR TITLE
Disregard `npm-debug.log`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/css/
 /dist/js/
 /dist/*.html
+/npm-debug.log


### PR DESCRIPTION
It's a purely-local file used only to capture errors from NPM. We never want it in Git.