### PR TITLE
Load polyfills from the vendor bundle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "dependencies": {
     "auth0-lock": "^9.2.1",
+    "babel-polyfill": "^6.9.0",
     "classnames": "^2.2.5",
     "detect-dom-ready": "^1.0.2",
     "jwt-decode": "^2.0.1",
@@ -21,7 +22,6 @@
   "devDependencies": {
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
-    "babel-polyfill": "^6.9.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "chai": "^3.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ var thisPackage = require('./package.json');
 
 module.exports = {
   entry: {
-    app: ['babel-polyfill', 'whatwg-fetch', "app.js"],
+    app: "app.js",
     vendor: keys(thisPackage.dependencies),
   },
 


### PR DESCRIPTION
After reading the code more closely, I realized the polyfills only have to be
executed to be loaded. Since the vendor bundle executes every top-level
dependency as a side effect of the way its contents are specified, adding the
polyfills to `dependencies` is enough to have them applied to the page.

The app bundle now contains only the app code.