### PR TITLE
Bridge client logs to Heroku.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,11 @@
 
 import domReady from 'detect-dom-ready';
 import asset from './app/asset';
+import io from 'socket.io-client';
+import logging from './app/logging';
+
+var socket = io();
+logging(console, socket);
 
 domReady(() => {
   // use explicit module index as a concession to Mac OS developers. Stops

--- a/js/app/lock/actions.js
+++ b/js/app/lock/actions.js
@@ -29,7 +29,7 @@ function refreshToken(dispatch, getState) {
   if (idToken) {
     lock.getClient().renewIdToken(idToken, (err, result) => {
       if (err) {
-        console.log("Failed to refresh ID token: ", err);
+        console.error('lock.refresh.failed', err);
         dispatch(abandon());
       }
       else
@@ -94,7 +94,7 @@ function bootFromHash(hash) {
     }));
 
     if (hash.error) {
-      console.log("Login hash error:", hash);
+      console.log('lock.hash.failed', hash.error);
       return;
     }
 

--- a/js/app/logging.js
+++ b/js/app/logging.js
@@ -1,0 +1,27 @@
+'use strict';
+
+function makeBridge(event, nativeEndpoint, socket) {
+  return function(...args) {
+    nativeEndpoint(...args);
+    socket.emit(event, args);
+  }
+}
+
+const TERMINALS = ['log', 'info', 'warn', 'error'];
+
+/*
+ * Forward log messages to terminals on `console` to the Socket.io socket
+ * `socket`. This patches each terminal (from TERMINALS) to first call the
+ * existing function, so that native browser logging continues uninterrupted
+ * even if the socket fails, and then forwards the call over the socket as a
+ * `console.TERMINAL` event (`console.log`, etc).
+ */
+export default function install(console, socket) {
+  for (var terminal of TERMINALS) {
+    if (console[terminal]) {
+      var event = `console.${terminal}`;
+      var nativeEndpoint = console[terminal].bind(console);
+      console[terminal] = makeBridge(event, nativeEndpoint, socket);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "redux": "^3.5.2",
     "redux-actions": "^0.9.1",
     "redux-thunk": "^2.1.0",
+    "socket.io-client": "^1.4.6",
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
@@ -40,6 +41,7 @@
     "less-plugin-autoprefix": "^1.5.1",
     "mocha": "^2.4.5",
     "morgan": "^1.7.0",
+    "socket.io": "^1.4.6",
     "transform-loader": "^0.2.3",
     "webpack": "^1.13.0",
     "yaml-loader": "^0.2.0"
@@ -54,5 +56,8 @@
     "postinstall": "npm run build",
     "test": "npm run karma",
     "web": "node web/server.js"
+  },
+  "engines": {
+    "node": "6.2.1"
   }
 }

--- a/web/logging.js
+++ b/web/logging.js
@@ -1,0 +1,32 @@
+'use strict';
+
+function makeBridge(endpoint, tags) {
+  return function(message) {
+    if (!Array.isArray(message))
+      message = [message];
+    var [first, ...rest] = message;
+    endpoint(first, ...tags, ...rest);
+  }
+}
+
+function connected(socket) {
+  var id = socket.id;
+  var address = socket.handshake.address;
+  var tags = [`client=${address}`, `socket=${id}`];
+
+  console.log('logging.connected', ...tags);
+
+  var terminals = ['log', 'info', 'warn', 'error'];
+  for (var terminal of terminals) {
+    var nativeEndpoint = console[terminal].bind(console);
+    socket.on(`console.${terminal}`, makeBridge(nativeEndpoint, tags));
+  }
+
+  socket.on('disconnect', function() {
+    console.log('logging.disconnected', ...tags);
+  });
+}
+
+module.exports = function install(io) {
+  io.on('connection', connected);
+}

--- a/web/server.js
+++ b/web/server.js
@@ -2,9 +2,12 @@
 
 var fs = require('fs');
 var path = require('path');
+var http = require('http');
 var express = require('express');
 var morgan = require('morgan');
 var handlebars = require('handlebars');
+var socketIo = require('socket.io');
+var logging = require('./logging');
 
 var port = process.env.PORT || 4000;
 
@@ -39,6 +42,10 @@ app.get(/.*/, function(req, res) {
   });
 });
 
-app.listen(port, function() {
+var server = http.Server(app);
+var io = socketIo(server);
+logging(io);
+
+server.listen(port, function() {
   console.log("started", `port=${port}`, `url=http://localhost:${port}/`);
 });


### PR DESCRIPTION
This should make it easier to diagnose client-side issues, or to add
log-based metrics to the client.

I've pinned the Node version to ensure that we get the required server-side
ES6 features (argument scatter, template strings).