### PR TITLE
Use fsevents to make `webpack --watch` use a reasonable amount of CPU.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
   },
   "engines": {
     "node": "6.2.1"
+  },
+  "optionalDependencies": {
+    "fsevents": "^1.0.12"
   }
 }


### PR DESCRIPTION
This dependency is optional; some platforms don't support it (hi, Windows!) but
do support webpack watch mode. Fail to the high-CPU polling approach when it's
not available, but use less than 100% of a CPU when it is.