### PR TITLE
Add tests for squad components.

### DIFF
--- a/src/app/squad/components/CharacterEditor.js
+++ b/src/app/squad/components/CharacterEditor.js
@@ -39,30 +39,30 @@ export default function CharacterEditor({
     </div>,
   }
 
-  return <div className="row">
+  return <div className="row character-editor">
     <div className="col-md-1">
-      <div className="form-group">
+      <div className="form-group hats-input">
         <CycleButtons
           options={HATS}
           value={sprite.hat}
           onSelect={hat => updateCharacterSprite(index, { hat, })} />
       </div>
 
-      <div className="form-group">
+      <div className="form-group hairs-input">
         <CycleButtons
           options={HAIRS}
           value={sprite.hair}
           onSelect={hair => updateCharacterSprite(index, { hair, })} />
       </div>
 
-      <div className="form-group">
+      <div className="form-group outfits-input">
         <CycleButtons
           options={OUTFITS}
           value={sprite.outfit}
           onSelect={outfit => updateCharacterSprite(index, { outfit, })} />
       </div>
 
-      <div className="form-group">
+      <div className="form-group genders-input">
         <OptionButtons
           buttonClassName="btn-sm"
           options={genders}
@@ -72,11 +72,16 @@ export default function CharacterEditor({
     </div>
 
     <div className="col-md-2">
-      <CharacterSprite width="100" height="160" className="center-block" facing="bottom-right" {...sprite} />
+      <CharacterSprite
+          width="100"
+          height="160"
+          className="center-block character-sprite"
+          facing="bottom-right"
+          {...sprite} />
     </div>
 
     <div className="col-md-7">
-      <div className="form-group">
+      <div className="form-group name-input">
         <label>Name
           <input
             type="text"
@@ -87,7 +92,7 @@ export default function CharacterEditor({
         </label>
       </div>
 
-      <div className="form-group">
+      <div className="form-group archetype-input">
         <OptionButtons
           options={archetypes}
           value={archetype}

--- a/src/app/squad/components/CycleButtons.js
+++ b/src/app/squad/components/CycleButtons.js
@@ -17,10 +17,10 @@ export default function CycleButtons({options, value, onSelect}) {
   const next = cycle(options, value, NEXT)
 
   return <div className="btn-group" data-toggle="buttons">
-    <button className="btn btn-sm btn-default" onClick={() => onSelect(next)}>
+    <button className="btn btn-prev btn-sm btn-default" onClick={() => onSelect(prev)}>
       &lt;
     </button>
-    <button className="btn btn-sm btn-default" onClick={() => onSelect(prev)}>
+    <button className="btn btn-next btn-sm btn-default" onClick={() => onSelect(next)}>
       &gt;
     </button>
   </div>

--- a/src/app/squad/components/SquadEditor.js
+++ b/src/app/squad/components/SquadEditor.js
@@ -14,43 +14,46 @@ import CharacterEditor from './CharacterEditor'
 
 const SquadEditor = React.createClass({
   componentWillMount() {
-    this.props.actions.loadSquad(this.props.api)
+    this.props.loadSquad(this.props.api)
   },
 
   render() {
-    var {characters, actions, workflow, api} = this.props
+    var {characters, workflow, api, saveSquad, ...props} = this.props
 
-    return <DocumentTitle title="Your Squad">
-      <div className="container">
-        <h1>Your Squad</h1>
-        {characters.reduce(
-          (elements, character, index) => {
-            return elements.length == 0 ? [
-              <CharacterEditor
-                key={`character-${index}`}
-                index={index}
-                {...character}
-                {...actions} />
-            ] : [
-              ...elements,
-              <hr key={`hr-${index}`} />,
-              <CharacterEditor
-                index={index}
-                key={`character-${index}`}
-                {...character}
-                {...actions} />
-            ]
-          },
-          []
-        )}
-        <button
-          className={classNames("btn", "btn-primary", {disabled: workflow.saving || workflow.loading})}
-          disabled={workflow.saving || workflow.loading}
-          onClick={() => actions.saveSquad(api)}>
-          {workflow.saving ? "Saving…" : workflow.loading ? "Loading…" : "Save & return to lobby"}
-        </button>
-      </div>
-    </DocumentTitle>
+    return <div className="container">
+      <h1>Your Squad</h1>
+      {characters.reduce(
+        (elements, character, index) => {
+          return elements.length == 0 ? [
+            <CharacterEditor
+              key={`character-${index}`}
+              index={index}
+              {...character}
+              {...props} />
+          ] : [
+            ...elements,
+            <hr key={`hr-${index}`} />,
+            <CharacterEditor
+              index={index}
+              key={`character-${index}`}
+              {...character}
+              {...props} />
+          ]
+        },
+        []
+      )}
+      <button
+        className={classNames({
+          'btn': true,
+          'btn-primary': true,
+          'btn-save': true,
+          'disabled': workflow.saving || workflow.loading,
+        })}
+        disabled={workflow.saving || workflow.loading}
+        onClick={() => saveSquad(api)}>
+        {workflow.saving ? "Saving…" : workflow.loading ? "Loading…" : "Save & return to lobby"}
+      </button>
+    </div>
   },
 })
 
@@ -59,12 +62,16 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return {
-    actions: bindActionCreators(actions, dispatch),
-  }
+  return bindActionCreators(actions, dispatch)
 }
 
-module.exports = connect(
+const SquadEditorPage = connect(
   mapStateToProps,
   mapDispatchToProps
-)(withApi(SquadEditor))
+)(withApi(props => <DocumentTitle title="Your Squad">
+  <SquadEditor {...props} />
+</DocumentTitle>))
+
+SquadEditorPage.Component = SquadEditor
+
+module.exports = SquadEditorPage

--- a/test/app/squad/components/CharacterEditor.spec.js
+++ b/test/app/squad/components/CharacterEditor.spec.js
@@ -1,0 +1,110 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import CharacterEditor from 'app/squad/components/CharacterEditor'
+
+describe('CharacterEditor', function() {
+  var name = 'Alice'
+  var index = 1
+
+  beforeEach(function() {
+    var archetype = 'SKIRMISHER'
+    var sprite = {
+      hair: '1',
+      hat: '0',
+      outfit: '1',
+      gender: 'F',
+    }
+
+    this.updateCharacterSprite = chai.spy()
+    this.changeCharacterName = chai.spy()
+    this.changeCharacterArchetype = chai.spy()
+    this.wrapper = mount(
+      <CharacterEditor
+        index={index}
+        archetype={archetype}
+        name={name}
+        sprite={sprite}
+        updateCharacterSprite={this.updateCharacterSprite}
+        changeCharacterName={this.changeCharacterName}
+        changeCharacterArchetype={this.changeCharacterArchetype} />
+    )
+  })
+
+  it('shows the selected sprite', function() {
+    var spriteImage = this.wrapper.find('.character-sprite image').get(0)
+
+    // "B", // "battle" sprites
+    // SPRITE_WIDTH, "x", SPRITE_HEIGHT,
+    // gender,
+    // "1", // sprite group
+    // "H", hair,
+    // "-", hat,
+    // "C", outfit,
+
+    expect(spriteImage.getAttribute('xlink:href')).to.match(/^.*[/]B128x240F1H1-0C1[.][0-9a-f]{32}[.]png$/)
+  })
+
+  it('edits hair', function() {
+    this.wrapper.find('.hairs-input .btn-next').simulate('click')
+    expect(this.updateCharacterSprite).to.have.been.called.with(index, {
+      hair: '2',
+    })
+  })
+
+  it('edits hat', function() {
+    this.wrapper.find('.hats-input .btn-next').simulate('click')
+    expect(this.updateCharacterSprite).to.have.been.called.with(index, {
+      hat: '1',
+    })
+  })
+
+  it('edits outfit', function() {
+    this.wrapper.find('.outfits-input .btn-next').simulate('click')
+    expect(this.updateCharacterSprite).to.have.been.called.with(index, {
+      outfit: '2',
+    })
+  })
+
+  it('shows the selected gender', function() {
+    var genderButtons = this.wrapper.find('.genders-input .btn-default')
+    expect(genderButtons.at(0)).to.have.className('active')
+    expect(genderButtons.at(1)).not.to.have.className('active')
+  })
+
+  it('edits gender', function() {
+    this.wrapper.find('.genders-input .btn-default').at(1).simulate('click')
+    expect(this.updateCharacterSprite).to.have.been.called.with(index, {
+      gender: 'M',
+    })
+  })
+
+  it('shows the name', function() {
+    expect(this.wrapper.find('.name-input input')).to.have.value('Alice')
+  })
+
+  it('edits the name', function() {
+    var nameInput = this.wrapper.find('.name-input input')
+    nameInput.get(0).value = 'Bob'
+    nameInput.simulate('change')
+
+    expect(this.changeCharacterName).to.have.been.called.with(index, 'Bob')
+  })
+
+  it('has three archetype buttons', function() {
+    var archetypeButtons = this.wrapper.find('.archetype-input .btn-default')
+    expect(archetypeButtons).to.have.length(3)
+  })
+
+  it('shows the selected archetype', function() {
+    var archetypeButtons = this.wrapper.find('.archetype-input .btn-default')
+    expect(archetypeButtons.at(0)).to.have.className('active')
+    expect(archetypeButtons.at(1)).not.to.have.className('active')
+    expect(archetypeButtons.at(2)).not.to.have.className('active')
+  })
+
+  it('edits the archetype', function() {
+    this.wrapper.find('.archetype-input .btn-default').at(1).simulate('click')
+    expect(this.changeCharacterArchetype).to.have.been.called.with(index, 'HUNTER')
+  })
+})

--- a/test/app/squad/components/CycleButtons.spec.js
+++ b/test/app/squad/components/CycleButtons.spec.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import CycleButtons from 'app/squad/components/CycleButtons'
+
+describe('CycleButtons', function () {
+  beforeEach(function () {
+    var options = ['A', 'B', 'C']
+    var option = 'A'
+
+    this.onSelect = chai.spy()
+    this.wrapper = mount(
+      <CycleButtons
+        options={options}
+        value={option}
+        onSelect={this.onSelect} />
+    )
+    this.buttons = this.wrapper.find('button')
+  })
+
+  it('renders a button group with left and right buttons', function () {
+    expect(this.wrapper).to.have.className('btn-group')
+
+    expect(this.buttons).to.have.length(2)
+    this.buttons.forEach(button => {
+      expect(button).to.have.className('btn')
+      expect(button).to.have.className('btn-default')
+    })
+    expect(this.buttons.at(0)).to.have.className('btn-prev')
+    expect(this.buttons.at(0)).to.have.text('<')
+    expect(this.buttons.at(1)).to.have.className('btn-next')
+    expect(this.buttons.at(1)).to.have.text('>')
+  })
+
+  it('returns the next value when a user clicks the > button', function () {
+    this.buttons.find('.btn-next').simulate('click')
+    expect(this.onSelect).to.have.been.called.with('B')
+  })
+
+  it('returns the next value when a user clicks the > button, wrapping as needed', function () {
+    var options = ['A', 'B', 'C']
+    var option = 'C'
+
+    var wrapper = mount(
+      <CycleButtons
+        options={options}
+        value={option}
+        onSelect={this.onSelect} />
+    )
+    var buttons = wrapper.find('button')
+
+    buttons.find('.btn-next').simulate('click')
+    expect(this.onSelect).to.have.been.called.with('A')
+  })
+
+  it('returns the previous value when a user clicks the < button, wrapping as needed', function () {
+    this.buttons.find('.btn-prev').simulate('click')
+    expect(this.onSelect).to.have.been.called.with('C')
+  })
+})

--- a/test/app/squad/components/OptionButtons.spec.js
+++ b/test/app/squad/components/OptionButtons.spec.js
@@ -3,46 +3,49 @@ import { mount } from 'enzyme'
 
 import OptionButtons from 'app/squad/components/OptionButtons'
 
-describe('OptionButtons', () => {
-  describe('using an array of options', () => {
-    var options = ['A', 'B']
-    var option = 'A'
-    var onSelect = chai.spy()
-    var wrapper = mount(
-      <OptionButtons
-        options={options}
-        value={option}
-        onSelect={onSelect} />
-    )
-    var buttons = wrapper.find('button')
+describe('OptionButtons', function() {
+  describe('using an array of options', function() {
+    beforeEach(function() {
+      var options = ['A', 'B']
+      var option = 'A'
 
-    it('renders a button group with two buttons', () => {
-      expect(wrapper).to.have.className('btn-group')
+      this.onSelect = chai.spy()
+      this.wrapper = mount(
+        <OptionButtons
+          options={options}
+          value={option}
+          onSelect={this.onSelect} />
+      )
+      this.buttons = this.wrapper.find('button')
+    })
 
-      expect(buttons).to.have.length(2)
-      buttons.forEach(button => {
+    it('renders a button group with two buttons', function() {
+      expect(this.wrapper).to.have.className('btn-group')
+
+      expect(this.buttons).to.have.length(2)
+      this.buttons.forEach(button => {
         expect(button).to.have.className('btn')
         expect(button).to.have.className('btn-default')
       })
     })
 
-    it('renders buttons labelled with the provided options', () => {
-      expect(buttons.at(0)).to.have.text('A')
-      expect(buttons.at(1)).to.have.text('B')
+    it('renders buttons labelled with the provided options', function() {
+      expect(this.buttons.at(0)).to.have.text('A')
+      expect(this.buttons.at(1)).to.have.text('B')
     })
 
-    it('highlights the active button', () => {
-      expect(buttons.at(0)).to.have.className('active')
-      expect(buttons.at(1)).not.to.have.className('active')
+    it('highlights the active button', function() {
+      expect(this.buttons.at(0)).to.have.className('active')
+      expect(this.buttons.at(1)).not.to.have.className('active')
     })
 
-    it('passes the clicked value back', () => {
-      buttons.at(1).simulate('click')
-      expect(onSelect).to.have.been.called.with('B')
+    it('passes the clicked value back', function() {
+      this.buttons.at(1).simulate('click')
+      expect(this.onSelect).to.have.been.called.with('B')
     })
   })
 
-  describe('using an options object', () => {
+  describe('using an options object', function() {
     var options = {
       'A': 'Label A',
       'B': <span id='label-b' />,
@@ -57,7 +60,7 @@ describe('OptionButtons', () => {
     )
     var buttons = wrapper.find('button')
 
-    it('renders a button group with two buttons', () => {
+    it('renders a button group with two buttons', function() {
       expect(wrapper).to.have.className('btn-group')
 
       expect(buttons).to.have.length(2)
@@ -67,23 +70,23 @@ describe('OptionButtons', () => {
       })
     })
 
-    it('renders buttons labelled with the provided options', () => {
+    it('renders buttons labelled with the provided options', function() {
       expect(buttons.at(0)).to.have.text('Label A')
       expect(buttons.at(1)).to.contain(<span id='label-b' />)
     })
 
-    it('highlights the active button', () => {
+    it('highlights the active button', function() {
       expect(buttons.at(0)).to.have.className('active')
       expect(buttons.at(1)).not.to.have.className('active')
     })
 
-    it('passes the clicked value back', () => {
+    it('passes the clicked value back', function() {
       buttons.at(1).simulate('click')
       expect(onSelect).to.have.been.called.with('B')
     })
   })
 
-  describe('with buttonClassName', () => {
+  describe('with buttonClassName', function() {
     var options = ['A', 'B']
     var wrapper = mount(
       <OptionButtons
@@ -92,7 +95,7 @@ describe('OptionButtons', () => {
     )
     var buttons = wrapper.find('button')
 
-    it('renders buttons that have the additional classes', () => {
+    it('renders buttons that have the additional classes', function() {
       expect(buttons).to.have.length(2)
       buttons.forEach(button => {
         expect(button).to.have.className('btn')

--- a/test/app/squad/components/SquadEditor.spec.js
+++ b/test/app/squad/components/SquadEditor.spec.js
@@ -1,0 +1,146 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import SquadEditor from 'app/squad/components/SquadEditor'
+
+describe('SquadEditor', function() {
+  var api = {
+    id: 'testing api dummy',
+  }
+
+  describe('when loading', function() {
+    var characters = []
+    var workflow = {
+      loading: true,
+      saving: false,
+    }
+
+    beforeEach(function() {
+      this.loadSquad = chai.spy()
+      this.wrapper = mount(
+        <SquadEditor.Component
+          api={api}
+          workflow={workflow}
+          characters={characters}
+          loadSquad={this.loadSquad} />
+      )
+    })
+
+    it('loads squads on mount', function() {
+      expect(this.loadSquad).to.have.been.called.with(api)
+    })
+
+    it('shows a disabled loading button', function() {
+      var saveButton = this.wrapper.find('.btn-save')
+      expect(saveButton).to.have.text('Loading…')
+      expect(saveButton).to.have.className('disabled')
+      expect(saveButton).to.have.attr('disabled')
+    })
+  })
+
+  describe('when quiescent', function() {
+    var characters = [
+      {
+        name: 'Alice',
+        archetype: 'SAGE',
+        sprite: {
+          hat: '0',
+          hair: '1',
+          outfit: '1',
+          gender: 'F',
+        },
+      },
+    ]
+    var workflow = {
+      loading: false,
+      saving: false,
+    }
+
+    beforeEach(function() {
+      this.loadSquad = chai.spy()
+      this.wrapper = mount(
+        <SquadEditor.Component
+          api={api}
+          workflow={workflow}
+          characters={characters}
+          loadSquad={this.loadSquad} />
+      )
+    })
+
+    it('loads squads on mount', function() {
+      /*
+       * yes, really, even when we're already loaded. Normally this component
+       * doesn't remount while displaying squads, but we allow it, and reload.
+       *
+       * This logic probably belongs in the route, honestly.
+       */
+      expect(this.loadSquad).to.have.been.called.with(api)
+    })
+
+    it('displays character editors for squads', function() {
+      var characters = this.wrapper.find('.character-editor')
+      expect(characters).to.have.length(1)
+      expect(characters.at(0).find('.name-input input')).to.have.value('Alice')
+    })
+
+    it('shows an enabled save button', function() {
+      var saveButton = this.wrapper.find('.btn-save')
+      expect(saveButton).to.have.text('Save & return to lobby')
+      expect(saveButton).not.to.have.className('disabled')
+      expect(saveButton).not.to.have.attr('disabled')
+    })
+  })
+
+  describe('when saving', function() {
+    var characters = [
+      {
+        name: 'Alice',
+        archetype: 'SAGE',
+        sprite: {
+          hat: '0',
+          hair: '1',
+          outfit: '1',
+          gender: 'F',
+        },
+      },
+    ]
+    var workflow = {
+      loading: false,
+      saving: true,
+    }
+
+    beforeEach(function() {
+      this.loadSquad = chai.spy()
+      this.wrapper = mount(
+        <SquadEditor.Component
+          api={api}
+          workflow={workflow}
+          characters={characters}
+          loadSquad={this.loadSquad} />
+      )
+    })
+
+    it('loads squads on mount', function() {
+      /*
+       * yes, really, even when we're already loaded. Normally this component
+       * doesn't remount while saving, but we allow it, and reload.
+       *
+       * This logic probably belongs in the route, honestly.
+       */
+      expect(this.loadSquad).to.have.been.called.with(api)
+    })
+
+    it('displays character editors for squads', function() {
+      var characters = this.wrapper.find('.character-editor')
+      expect(characters).to.have.length(1)
+      expect(characters.at(0).find('.name-input input')).to.have.value('Alice')
+    })
+
+    it('shows a disabled save button', function() {
+      var saveButton = this.wrapper.find('.btn-save')
+      expect(saveButton).to.have.text('Saving…')
+      expect(saveButton).to.have.className('disabled')
+      expect(saveButton).to.have.attr('disabled')
+    })
+  })
+})


### PR DESCRIPTION
Via @wlonk, I've realized my test for OptionButtons was wrong. It turns out that polluting the `describe()` scope with stateful things like callbacks doesn't work the way I thought it did. This new implementation creates state per test, rather than shared state per suite.

I've started adding CSS classes to "interesting" elements. I explored refactoring the CSS to use these classes, rather than bare bootstrap classes, to style elements, but that turns out to be impractical: bootstrap relies on complex nests of selectors, and binding custom classes to those relationships is error-prone. Instead, semantic classes sit alongside presentation classes in the markup.