### PR TITLE
Moved boot logic out of individual components.

### DIFF
--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -3,30 +3,16 @@
 import React from 'react'
 import DocumentTitle from 'react-document-title'
 
-import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import { withApi } from 'app/api'
-import { withLock } from 'app/lock/components'
-import { boot } from 'app/lock/actions'
 
-const App = React.createClass({
-  componentDidMount() {
-    var {api, lock} = this.props
-    this.props.boot(api, lock)
-  },
-
-  render() {
-    var {booting, children} = this.props
-
-    return <DocumentTitle title="Distant Shore">
-    { !booting &&
-      children
-    }
-    </DocumentTitle>
-  },
-})
+function App({booting, children}) {
+  return <DocumentTitle title="Distant Shore">
+  { !booting &&
+    children
+  }
+  </DocumentTitle>
+}
 
 module.exports = connect(
-  state => state.lock,
-  dispatch => bindActionCreators({boot}, dispatch)
-)(withApi(withLock(App)))
+  state => state.lock
+)(App)

--- a/src/app/components/Landing.js
+++ b/src/app/components/Landing.js
@@ -6,7 +6,6 @@ import { connect } from 'react-redux'
 
 import { withLock } from 'app/lock/components'
 import * as lockActions from 'app/lock/actions'
-import * as actions from '../actions'
 
 import LoggedIn from './Landing/LoggedIn'
 import Anonymous from './Landing/Anonymous'
@@ -27,6 +26,5 @@ module.exports = connect(
   }),
   dispatch => bindActionCreators({
     ...lockActions,
-    ...actions,
   }, dispatch)
 )(withLock(Landing))

--- a/src/app/components/Landing.js
+++ b/src/app/components/Landing.js
@@ -1,85 +1,23 @@
 'use strict'
 
 import React from 'react'
-import { Link } from 'react-router'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import jwtDecode from 'jwt-decode'
 
-import { withApi } from 'app/api'
 import { withLock } from 'app/lock/components'
 import * as lockActions from 'app/lock/actions'
 import * as actions from '../actions'
 
-function LoggedInLanding({idToken, profile, logout, lock}) {
-  return <div className="container">
-    <div className="col-md-3">
-      <ul>
-        <li><Link to="squad">Squad</Link></li>
-      </ul>
-    </div>
-    <div className="col-md-9">
-      <p>ID token:</p>
-      <pre>{JSON.stringify(jwtDecode(idToken), null, "  ")}</pre>
-      <p>Profile:</p>
-      {profile &&
-        <pre>{JSON.stringify(profile, null, "  ")}</pre>}
-      <button className="btn btn-default" onClick={() => logout(lock)}>Log out</button>
-    </div>
-  </div>
-}
-
-function LandingCopy() {
-  return <div className="jumbotron">
-    <h1>Distant Shore</h1>
-    <p>
-      Knausgaard taxidermy gochujang polaroid. Lo-fi truffaut schlitz,
-      gluten-free forage pickled biodiesel beard meggings keytar art party
-      stumptown slow-carb craft beer.
-    </p>
-    <p>
-      In the finished app, this should be a preview of a live fight, or a
-      recording.
-    </p>
-  </div>
-}
-
-const AnonymousLanding = React.createClass({
-  componentDidMount() {
-    var {login, lock} = this.props
-    login(lock, {
-      container: "auth0-lock",
-    })
-  },
-
-  render() {
-    return <div className="container">
-      <div id="auth0-lock" className="col-md-4"/>
-      <div className="col-md-8">
-        <LandingCopy />
-      </div>
-    </div>
-  },
-})
-
-const LoadingLanding = withApi(React.createClass({
-  componentWillMount() {
-    var {openSquadIfNeeded, api} = this.props
-
-    openSquadIfNeeded(api)
-  },
-
-  render() {
-    return false
-  },
-}))
+import LoggedIn from './Landing/LoggedIn'
+import Anonymous from './Landing/Anonymous'
+import Loading from './Landing/Loading'
 
 function Landing({idToken, loading, ...props}) {
   if (!idToken)
-    return <AnonymousLanding {...props} />
+    return <Anonymous {...props} />
   if (loading)
-    return <LoadingLanding {...props} />
-  return <LoggedInLanding idToken={idToken} {...props} />
+    return <Loading {...props} />
+  return <LoggedIn idToken={idToken} {...props} />
 }
 
 module.exports = connect(

--- a/src/app/components/Landing/Anonymous.js
+++ b/src/app/components/Landing/Anonymous.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import Copy from './Copy'
+
+const AnonymousLanding = React.createClass({
+  componentDidMount() {
+    var {login, lock} = this.props
+    login(lock, {
+      container: "auth0-lock",
+    })
+  },
+
+  render() {
+    return <div className="container">
+      <div id="auth0-lock" className="col-md-4"/>
+      <div className="col-md-8">
+        <Copy />
+      </div>
+    </div>
+  },
+})
+
+export default AnonymousLanding

--- a/src/app/components/Landing/Copy.js
+++ b/src/app/components/Landing/Copy.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function Copy() {
+  return <div className="jumbotron">
+    <h1>Distant Shore</h1>
+    <p>
+      Knausgaard taxidermy gochujang polaroid. Lo-fi truffaut schlitz,
+      gluten-free forage pickled biodiesel beard meggings keytar art party
+      stumptown slow-carb craft beer.
+    </p>
+    <p>
+      In the finished app, this should be a preview of a live fight, or a
+      recording.
+    </p>
+  </div>
+}

--- a/src/app/components/Landing/Loading.js
+++ b/src/app/components/Landing/Loading.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { withApi } from 'app/api'
+
+const Loading = withApi(React.createClass({
+  componentWillMount() {
+    var {openSquadIfNeeded, api} = this.props
+
+    openSquadIfNeeded(api)
+  },
+
+  render() {
+    return false
+  },
+}))
+
+export default Loading

--- a/src/app/components/Landing/Loading.js
+++ b/src/app/components/Landing/Loading.js
@@ -1,16 +1,3 @@
-import React from 'react'
-import { withApi } from 'app/api'
-
-const Loading = withApi(React.createClass({
-  componentWillMount() {
-    var {openSquadIfNeeded, api} = this.props
-
-    openSquadIfNeeded(api)
-  },
-
-  render() {
-    return false
-  },
-}))
-
-export default Loading
+export default function Loading() {
+  return false
+}

--- a/src/app/components/Landing/LoggedIn.js
+++ b/src/app/components/Landing/LoggedIn.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Link } from 'react-router'
+import jwtDecode from 'jwt-decode'
+
+export default function LoggedIn({idToken, profile, logout, lock}) {
+  return <div className="container">
+    <div className="col-md-3">
+      <ul>
+        <li><Link to="squad">Squad</Link></li>
+      </ul>
+    </div>
+    <div className="col-md-9">
+      <p>ID token:</p>
+      <pre>{JSON.stringify(jwtDecode(idToken), null, "  ")}</pre>
+      <p>Profile:</p>
+      {profile &&
+        <pre>{JSON.stringify(profile, null, "  ")}</pre>}
+      <button className="btn btn-default" onClick={() => logout(lock)}>Log out</button>
+    </div>
+  </div>
+}

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -43,7 +43,7 @@ ReactDOM.render(
   <Provider store={store}>
     <ApiProvider api={api}>
       <LockProvider lock={lock}>
-        <Router routes={routes} history={history} />
+        <Router routes={routes(store, api, lock)} history={history} />
       </LockProvider>
     </ApiProvider>
   </Provider>,

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -1,12 +1,30 @@
-'use strict'
+import { bindActionCreators } from 'redux'
 
-module.exports = {
-  path: '/',
-  component: require('./components/App'),
-  indexRoute: {
-    component: require('./components/Landing'),
-  },
-  childRoutes: [
-    require('./squad/routes'),
-  ],
+import * as actions from 'app/actions'
+import * as lockActions from 'app/lock/actions'
+
+function routes(store, api, lock) {
+  var dispatch = bindActionCreators({
+    ...actions,
+    ...lockActions,
+  }, store.dispatch)
+
+  return {
+    path: '/',
+    onEnter() {
+      dispatch.boot(api, lock)
+    },
+    component: require('./components/App'),
+    indexRoute: {
+      onEnter() {
+        dispatch.openSquadIfNeeded(api)
+      },
+      component: require('./components/Landing'),
+    },
+    childRoutes: [
+      require('./squad/routes')(store, api),
+    ],
+  }
 }
+
+module.exports = routes

--- a/src/app/squad/components/SquadEditor.js
+++ b/src/app/squad/components/SquadEditor.js
@@ -11,50 +11,42 @@ import { withApi } from 'app/api'
 import * as actions from '../actions'
 import CharacterEditor from './CharacterEditor'
 
-const SquadEditor = React.createClass({
-  componentWillMount() {
-    this.props.loadSquad(this.props.api)
-  },
-
-  render() {
-    var {characters, workflow, api, saveSquad, ...props} = this.props
-
-    return <div className="container">
-      <h1>Your Squad</h1>
-      {characters.reduce(
-        (elements, character, index) => {
-          return elements.length == 0 ? [
-            <CharacterEditor
-              key={`character-${index}`}
-              index={index}
-              {...character}
-              {...props} />
-          ] : [
-            ...elements,
-            <hr key={`hr-${index}`} />,
-            <CharacterEditor
-              index={index}
-              key={`character-${index}`}
-              {...character}
-              {...props} />
-          ]
-        },
-        []
-      )}
-      <button
-        className={classNames({
-          'btn': true,
-          'btn-primary': true,
-          'btn-save': true,
-          'disabled': workflow.saving || workflow.loading,
-        })}
-        disabled={workflow.saving || workflow.loading}
-        onClick={() => saveSquad(api)}>
-        {workflow.saving ? "Saving…" : workflow.loading ? "Loading…" : "Save & return to lobby"}
-      </button>
-    </div>
-  },
-})
+function SquadEditor({characters, workflow, api, saveSquad, ...props}) {
+  return <div className="container">
+    <h1>Your Squad</h1>
+    {characters.reduce(
+      (elements, character, index) => {
+        return elements.length == 0 ? [
+          <CharacterEditor
+            key={`character-${index}`}
+            index={index}
+            {...character}
+            {...props} />
+        ] : [
+          ...elements,
+          <hr key={`hr-${index}`} />,
+          <CharacterEditor
+            index={index}
+            key={`character-${index}`}
+            {...character}
+            {...props} />
+        ]
+      },
+      []
+    )}
+    <button
+      className={classNames({
+        'btn': true,
+        'btn-primary': true,
+        'btn-save': true,
+        'disabled': workflow.saving || workflow.loading,
+      })}
+      disabled={workflow.saving || workflow.loading}
+      onClick={() => saveSquad(api)}>
+      {workflow.saving ? "Saving…" : workflow.loading ? "Loading…" : "Save & return to lobby"}
+    </button>
+  </div>
+}
 
 function mapStateToProps(state) {
   return state.squad

--- a/src/app/squad/routes.js
+++ b/src/app/squad/routes.js
@@ -1,6 +1,17 @@
-'use strict'
+import { bindActionCreators } from 'redux'
 
-module.exports = {
-  path: 'squad',
-  component: require('./components/SquadEditor'),
+import * as actions from './actions'
+
+function routes(store, api) {
+  var dispatch = bindActionCreators(actions, store.dispatch)
+
+  return {
+    path: 'squad',
+    onEnter() {
+      dispatch.loadSquad(api)
+    },
+    component: require('./components/SquadEditor'),
+  }
 }
+
+module.exports = routes

--- a/test/app/squad/components/SquadEditor.spec.js
+++ b/test/app/squad/components/SquadEditor.spec.js
@@ -26,10 +26,6 @@ describe('SquadEditor', function() {
       )
     })
 
-    it('loads squads on mount', function() {
-      expect(this.loadSquad).to.have.been.called.with(api)
-    })
-
     it('shows a disabled loading button', function() {
       var saveButton = this.wrapper.find('.btn-save')
       expect(saveButton).to.have.text('Loading…')
@@ -65,16 +61,6 @@ describe('SquadEditor', function() {
           characters={characters}
           loadSquad={this.loadSquad} />
       )
-    })
-
-    it('loads squads on mount', function() {
-      /*
-       * yes, really, even when we're already loaded. Normally this component
-       * doesn't remount while displaying squads, but we allow it, and reload.
-       *
-       * This logic probably belongs in the route, honestly.
-       */
-      expect(this.loadSquad).to.have.been.called.with(api)
     })
 
     it('displays character editors for squads', function() {
@@ -118,16 +104,6 @@ describe('SquadEditor', function() {
           characters={characters}
           loadSquad={this.loadSquad} />
       )
-    })
-
-    it('loads squads on mount', function() {
-      /*
-       * yes, really, even when we're already loaded. Normally this component
-       * doesn't remount while saving, but we allow it, and reload.
-       *
-       * This logic probably belongs in the route, honestly.
-       */
-      expect(this.loadSquad).to.have.been.called.with(api)
     })
 
     it('displays character editors for squads', function() {


### PR DESCRIPTION
By creating a route factory, rather than creating a simple route object, it's now possible to inject dependencies into the router. This means that, for example, route enter and leave hooks can interact with the Redux store and with the API.

This simplifies individual components by quite a bit, as they no longer rely on having access to the API _on mount_ and can instead be mounted safely in contexts where the API is unavailable.